### PR TITLE
FIX: OpenCL build failed on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(hwinfo VERSION 1.0.0 LANGUAGES CXX)
 
 if (WIN32)
     add_definitions(-DWIN32)
+    add_compile_definitions(NOMINMAX)
     set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 endif()
 
@@ -47,7 +48,7 @@ option(HWINFO_CPU "Enable CPU information" ON)
 option(HWINFO_DISK "Enable disk information" ON)
 option(HWINFO_RAM "Enable RAM information" ON)
 option(HWINFO_GPU "Enable GPU information" ON)
-option(HWINFO_GPU_OPENCL "Enable OpenCL for more GPU information" OFF)
+option(HWINFO_GPU_OPENCL "Enable OpenCL for more GPU information" ON)
 option(HWINFO_BATTERY "Enable battery information" ON)
 option(HWINFO_NETWORK "Enable network information" ON)
 

--- a/include/hwinfo/opencl/device.h
+++ b/include/hwinfo/opencl/device.h
@@ -10,7 +10,7 @@
 #include <cstdint>
 #include <iostream>
 
-#include "../../../cmake-build-release/_deps/opencl-src/external/OpenCL-CLHPP/include/CL/opencl.hpp"
+#include "CL/opencl.hpp"
 
 namespace opencl_ {
 


### PR DESCRIPTION
On Windows platform, if OpenCL is not enabled, the GPU memory value returned by the WMI interface is limited to 4-byte length, which often fails to obtain the correct value for contemporary graphics cards. This also fixes the conflict between OpenCL and Windows MIN MAX macros, as well as the issue where OpenCL header files contained the original author's local path information that could easily cause errors.