### PR TITLE
fix opencl_device cmake issue

### DIFF
--- a/src/opencl/CMakeLists.txt
+++ b/src/opencl/CMakeLists.txt
@@ -17,5 +17,11 @@ else()
 endif()
 
 add_library(opencl_device STATIC device.cpp)
-target_include_directories(opencl_device PUBLIC ${PROJECT_SOURCE_DIR}/include)
+target_include_directories(opencl_device PRIVATE ${PROJECT_SOURCE_DIR}/include)
 target_link_libraries(opencl_device PUBLIC OpenCL::HeadersCpp OpenCL::OpenCL)
+
+install(TARGETS opencl_device
+        EXPORT lfreist-hwinfoTargets
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
FIX: CMake Error: install(EXPORT "lfreist-hwinfoTargets" ...) includes target "hwinfo_gpu" which requires target "opencl_device" that is not in any export set.